### PR TITLE
Test on all push'es

### DIFF
--- a/.github/workflows/mdbook-test.yml
+++ b/.github/workflows/mdbook-test.yml
@@ -1,0 +1,25 @@
+# Sample workflow for building and deploying a mdBook site to GitHub Pages
+#
+# To get started with mdBook see: https://rust-lang.github.io/mdBook/index.html
+#
+name: Test mdBook
+
+on: [push]
+
+jobs:
+
+  # Build job
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: 0.4.28
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install mdBook
+        run: |
+          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
+          rustup update
+          cargo install --version ${MDBOOK_VERSION} mdbook
+      - name: Test with mdBook
+        run: mdbook test

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -2,7 +2,7 @@
 
 [](WELCOME.md)
 
-- [PowerView Introduction](PowerView%20Introduction/Powerview%20Introduction.md)
+- [PowerView Introduction](PowerView%20Introduction/Powerview%20Introduction.md2)
   - [System Highlights](PowerView%20Introduction/System%20Highlights/System%20Highlights.md)
   - [Functional Architecture](PowerView%20Introduction/Functional%20Architecture/Functional%20Architecture.md)
   - [Software Architecture](PowerView%20Introduction/Software%20Architecture/Software%20Architecture.md)


### PR DESCRIPTION
This PR introduces a GitHub action to always run `mdbook tests` on pushes.